### PR TITLE
fix: no longer depends on fastify or express types

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,12 +33,12 @@ devDependencies:
   rimraf: 3.0.2
   rxjs: 6.6.2
   supertest: 4.0.2
-  ts-jest: 26.1.0_jest@26.0.1
-  ts-loader: 6.2.2
-  ts-node: 8.10.2
+  ts-jest: 26.1.0_jest@26.0.1+typescript@3.9.7
+  ts-loader: 6.2.2_typescript@3.9.7
+  ts-node: 8.10.2_typescript@3.9.7
   tsconfig-paths: 3.9.0
   typescript: 3.9.7
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@angular-devkit/core/10.0.7:
     dependencies:
@@ -1388,7 +1388,7 @@ packages:
       jest-haste-map: 26.3.0
       jest-message-util: 26.3.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-resolve: 26.4.0
       jest-resolve-dependencies: 26.4.2
       jest-runner: 26.4.2
       jest-runtime: 26.4.2
@@ -1458,7 +1458,7 @@ packages:
       istanbul-lib-source-maps: 4.0.0
       istanbul-reports: 3.0.2
       jest-haste-map: 26.3.0
-      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-resolve: 26.4.0
       jest-util: 26.3.0
       jest-worker: 26.3.0
       slash: 3.0.0
@@ -1573,7 +1573,7 @@ packages:
       tsconfig-paths: 3.9.0
       tsconfig-paths-webpack-plugin: 3.3.0
       typescript: 3.9.7
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
       webpack-node-externals: 2.5.1
     dev: true
     engines:
@@ -7109,7 +7109,7 @@ packages:
       jest-get-type: 26.3.0
       jest-jasmine2: 26.4.2
       jest-regex-util: 26.0.0
-      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-resolve: 26.4.0
       jest-util: 26.3.0
       jest-validate: 26.4.2
       micromatch: 4.0.2
@@ -7293,7 +7293,7 @@ packages:
       integrity: sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==
   /jest-pnp-resolver/1.2.2_jest-resolve@26.4.0:
     dependencies:
-      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-resolve: 26.4.0
     dev: true
     engines:
       node: '>=6'
@@ -7320,7 +7320,7 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-ADHaOwqEcVc71uTfySzSowA/RdxUpCxhxa2FNLiin9vWLB1uLPad3we+JSSROq5+SrL9iYPdZZF8bdKM7XABTQ==
-  /jest-resolve/26.4.0_jest-resolve@26.4.0:
+  /jest-resolve/26.4.0:
     dependencies:
       '@jest/types': 26.3.0
       chalk: 4.1.0
@@ -7333,8 +7333,6 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
-    peerDependencies:
-      jest-resolve: '*'
     resolution:
       integrity: sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==
   /jest-runner/26.4.2:
@@ -7353,7 +7351,7 @@ packages:
       jest-haste-map: 26.3.0
       jest-leak-detector: 26.4.2
       jest-message-util: 26.3.0
-      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-resolve: 26.4.0
       jest-runtime: 26.4.2
       jest-util: 26.3.0
       jest-worker: 26.3.0
@@ -7385,7 +7383,7 @@ packages:
       jest-message-util: 26.3.0
       jest-mock: 26.3.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-resolve: 26.4.0
       jest-snapshot: 26.4.2
       jest-util: 26.3.0
       jest-validate: 26.4.2
@@ -7420,7 +7418,7 @@ packages:
       jest-haste-map: 26.3.0
       jest-matcher-utils: 26.4.2
       jest-message-util: 26.3.0
-      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-resolve: 26.4.0
       natural-compare: 1.4.0
       pretty-format: 26.4.2
       semver: 7.3.2
@@ -10851,7 +10849,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.44.1_webpack@4.44.1
+      webpack: 4.44.1
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: true
@@ -11072,7 +11070,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
-  /ts-jest/26.1.0_jest@26.0.1:
+  /ts-jest/26.1.0_jest@26.0.1+typescript@3.9.7:
     dependencies:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
@@ -11084,6 +11082,7 @@ packages:
       micromatch: 4.0.2
       mkdirp: 1.0.4
       semver: 7.3.2
+      typescript: 3.9.7
       yargs-parser: 18.1.3
     dev: true
     engines:
@@ -11094,13 +11093,14 @@ packages:
       typescript: '>=3.8 <4.0'
     resolution:
       integrity: sha512-JbhQdyDMYN5nfKXaAwCIyaWLGwevcT2/dbqRPsQeh6NZPUuXjZQZEfeLb75tz0ubCIgEELNm6xAzTe5NXs5Y4Q==
-  /ts-loader/6.2.2:
+  /ts-loader/6.2.2_typescript@3.9.7:
     dependencies:
       chalk: 2.4.2
       enhanced-resolve: 4.3.0
       loader-utils: 1.4.0
       micromatch: 4.0.2
       semver: 6.3.0
+      typescript: 3.9.7
     dev: true
     engines:
       node: '>=8.6'
@@ -11117,12 +11117,13 @@ packages:
     optional: true
     resolution:
       integrity: sha512-BUKSoz7AFSKPcYTZODbICW2mOthAN4vc5juD6FL1lD/dLwZ0WvrC3zqBM3/X6f5gHxq3yaz+HmanHGaWm0ddbQ==
-  /ts-node/8.10.2:
+  /ts-node/8.10.2_typescript@3.9.7:
     dependencies:
       arg: 4.1.3
       diff: 4.0.2
       make-error: 1.3.6
       source-map-support: 0.5.19
+      typescript: 3.9.7
       yn: 3.1.1
     dev: true
     engines:
@@ -11543,7 +11544,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
-  /webpack/4.44.1_webpack@4.44.1:
+  /webpack/4.44.1:
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -11573,7 +11574,6 @@ packages:
       node: '>=6.11.5'
     hasBin: true
     peerDependencies:
-      webpack: '*'
       webpack-cli: '*'
       webpack-command: '*'
     peerDependenciesMeta:

--- a/src/cookie.interface.ts
+++ b/src/cookie.interface.ts
@@ -1,6 +1,3 @@
-import { Request } from 'express';
-import { FastifyRequest } from 'fastify';
-
 export interface Cookie {
   name: string;
   value: any;
@@ -15,14 +12,7 @@ export interface Cookie {
   };
 }
 
-export interface ExpressCookieRequest extends Request {
+export type NestCookieRequest<T> = T & {
   _cookies: Cookie[];
   cookies: Record<string, string>;
-}
-
-export interface FastifyCookieRequest extends FastifyRequest {
-  _cookies: Cookie[];
-  cookies: Record<string, string>;
-}
-
-export type NestCookieRequest = ExpressCookieRequest | FastifyCookieRequest;
+};

--- a/src/cookie.module.ts
+++ b/src/cookie.module.ts
@@ -35,7 +35,11 @@ export class CookieModule implements OnModuleInit, NestModule {
     return this.adapterHost.httpAdapter.getType() === 'fastify';
   }
 
-  private parseCookies(req: NestCookieRequest, res, next): void {
+  private parseCookies(
+    req: NestCookieRequest<{ headers: Record<string, any> }>,
+    res,
+    next,
+  ): void {
     req._cookies = [];
     req.cookies = {};
     const cookieHeader: string = req.headers['cookie'] ?? '';

--- a/src/cookies.interceptor.ts
+++ b/src/cookies.interceptor.ts
@@ -4,8 +4,6 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import { Response } from 'express';
-import { FastifyReply } from 'fastify';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { Cookie, NestCookieRequest } from './cookie.interface';
@@ -58,7 +56,10 @@ export class CookiesInterceptor implements NestInterceptor {
 
   public getRequestResponse(
     context: ExecutionContext,
-  ): { req: NestCookieRequest; res: Response | FastifyReply } {
+  ): {
+    req: NestCookieRequest<unknown>;
+    res: { header: (key: string, value: string[]) => void };
+  } {
     const http = context.switchToHttp();
     return { req: http.getRequest(), res: http.getResponse() };
   }

--- a/test/app.controller.ts
+++ b/test/app.controller.ts
@@ -8,13 +8,13 @@ export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
-  getHello(@Req() req: NestCookieRequest): string {
+  getHello(@Req() req: NestCookieRequest<unknown>): string {
     console.log(req.cookies);
     return this.appService.getHello();
   }
 
   @Get('add-cookie')
-  addCookie(@Req() req: NestCookieRequest): string {
+  addCookie(@Req() req: NestCookieRequest<unknown>): string {
     const expires = new Date();
     expires.setDate(expires.getDate() + 1);
     req._cookies = [

--- a/test/app.resolver.ts
+++ b/test/app.resolver.ts
@@ -9,13 +9,13 @@ import { GqlCookieInterceptor } from './graphql-cookie.interceptor';
 export class AppResolver {
   constructor(private readonly appService: AppService) {}
   @Query(() => String)
-  sayHello(@Context() ctx: { req: NestCookieRequest }): string {
+  sayHello(@Context() ctx: { req: NestCookieRequest<unknown> }): string {
     console.log(ctx.req.cookies);
     return this.appService.getHello();
   }
 
   @Query(() => String)
-  addCookie(@Context() ctx: { req: NestCookieRequest }): string {
+  addCookie(@Context() ctx: { req: NestCookieRequest<unknown> }): string {
     const expires = new Date();
     expires.setDate(expires.getDate() + 1);
     ctx.req._cookies = [

--- a/test/graphql-cookie.interceptor.ts
+++ b/test/graphql-cookie.interceptor.ts
@@ -6,7 +6,9 @@ import { CookiesInterceptor, NestCookieRequest } from '../src';
 
 @Injectable()
 export class GqlCookieInterceptor extends CookiesInterceptor {
-  getRequestResponse(context: ExecutionContext): { req: NestCookieRequest, res: Response | FastifyReply } {
+  getRequestResponse(
+    context: ExecutionContext,
+  ): { req: NestCookieRequest<unknown>; res: Response | FastifyReply } {
     const gqlCtx = GqlExecutionContext.create(context);
     return gqlCtx.getContext();
   }


### PR DESCRIPTION
I was able to implement a generic type for `NestCookieRequest`
that can be extended to work with `Request` and `FastfyRequest`
without worrying about having both installed for the module to work
in the first place. This will allow for greater freedom to devs
so they don't have to bloat their dependencies with unnecessary
packages.

fix: #2