### PR TITLE
symmetric encodeURIComponent/decodeURIComponent

### DIFF
--- a/src/cookie.module.ts
+++ b/src/cookie.module.ts
@@ -48,7 +48,7 @@ export class CookieModule implements OnModuleInit, NestModule {
       .filter(cookie => !!cookie)
       .forEach((cookie: string) => {
         const [cookieName, cookieValue] = cookie.split('=');
-        req.cookies[cookieName] = cookieValue;
+        req.cookies[cookieName] = decodeURIComponent(cookieValue);
       });
     next();
   }


### PR DESCRIPTION
Here: https://github.com/jmcdo29/nest-cookies/blob/174b4533d067fc7abf95cb861facab20cd20ed63/src/cookies.interceptor.ts#L51
Cookie value is encoded when set. But when read, not decoded. Thus, symmetric `JSON.stringify`/`JSON.parse` fail.